### PR TITLE
Feature/Fix: Add-on adapted for acore & client 3.3.5

### DIFF
--- a/CustomItemFix/CustomItemFix.toc
+++ b/CustomItemFix/CustomItemFix.toc
@@ -1,7 +1,8 @@
-## Interface: 20400
-## Title: |cffff8000Custom Item Icon Fix|r
+## Interface: 30300
+## Title: CustomItemFix
 ## Version: 0.1.2
 ## Notes: Enables icons on custom items
 ## Author: Ethos
-CustomItemFix.xml
 
+CustomItemFix.lua
+CustomItemFixSupport.lua

--- a/CustomItemFix/CustomItemFix.toc
+++ b/CustomItemFix/CustomItemFix.toc
@@ -1,6 +1,6 @@
 ## Interface: 30300
 ## Title: CustomItemFix
-## Version: 0.1.2
+## Version: 0.1.3
 ## Notes: Enables icons on custom items
 ## Author: Ethos
 

--- a/CustomItemFix/CustomItemFix.xml
+++ b/CustomItemFix/CustomItemFix.xml
@@ -1,4 +1,0 @@
-<Ui xmlns="http://www.blizzard.com/wow/ui/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.blizzard.com/wow/ui/ ..\FrameXML\UI.xsd">
-<Script file="CustomItemFix.lua"/>
-<Script file="CustomItemFixSupport.lua"/>
-</Ui>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # CustomItemFix
-Addon to fix custom item icons
+Simple client addon to fix custom item icons
+
+## Installation
+- Drop the folder "/CustomItemFix" containing the 2 lua scripts into your folder "/World of Warcraft/Interface/AddOns"
+- Activate the addon in the character selection menu


### PR DESCRIPTION
Adapted/fixed (low effort fix) for the 3.3.5 MMO client

Test with latest AzerothCore server and 3.3.5 client (adding a custom item not present in dbc) :
![image](https://github.com/user-attachments/assets/2aba0761-c1eb-461f-9af0-c49e0796fd48)
![image](https://github.com/user-attachments/assets/b18dea8f-765c-43b4-bc56-31dc30765e8a)
![image](https://github.com/user-attachments/assets/6c627e2e-5c6b-4493-967f-d81a4173a023)
The icon is now present even without dbc update
